### PR TITLE
feat(question): scope cluster actions on backend

### DIFF
--- a/src/main/java/line4thon/boini/audience/question/dto/ClusterItem.java
+++ b/src/main/java/line4thon/boini/audience/question/dto/ClusterItem.java
@@ -3,8 +3,11 @@ package line4thon.boini.audience.question.dto;
 import java.util.List;
 
 public record ClusterItem(
+    String clusterId,
+    String representativeQuestionId,
     String representative,
     int count,
+    List<ClusterQuestionItem> questions,
     List<String> questionIds,
     List<Integer> slides,
     List<String> samples

--- a/src/main/java/line4thon/boini/audience/question/dto/ClusterQuestionItem.java
+++ b/src/main/java/line4thon/boini/audience/question/dto/ClusterQuestionItem.java
@@ -1,0 +1,9 @@
+package line4thon.boini.audience.question.dto;
+
+public record ClusterQuestionItem(
+    String id,
+    String content,
+    int slide,
+    long ts,
+    String status
+) {}

--- a/src/main/java/line4thon/boini/audience/question/service/ClusterBroadcaster.java
+++ b/src/main/java/line4thon/boini/audience/question/service/ClusterBroadcaster.java
@@ -42,6 +42,38 @@ public class ClusterBroadcaster {
     }
   }
 
+  public ClusterReportResponse refreshClusters(String roomId) {
+    try {
+      FastApiClusterResponse resp = fastApiWebClient.post()
+          .uri("/report/questions/rooms/{roomId}/clusters/refresh", roomId)
+          .retrieve()
+          .bodyToMono(FastApiClusterResponse.class)
+          .block(Duration.ofSeconds(10));
+
+      return (resp != null) ? resp.data() : null;
+    } catch (Exception e) {
+      log.warn("[CLUSTER] 상태 갱신 실패 (roomId={}): {}", roomId, e.getMessage());
+      return null;
+    }
+  }
+
+  public void broadcastClusters(String roomId, ClusterReportResponse report) {
+    if (report == null) return;
+    broker.convertAndSend(
+        "/topic/p/" + roomId + "/clusters",
+        ClusterEvent.updated(report)
+    );
+    log.info("[CLUSTER] 상태 broadcast 완료 (roomId={}, groups={})", roomId, report.uniqueGroups());
+  }
+
+  public void refreshAndBroadcast(String roomId) {
+    ClusterReportResponse report = refreshClusters(roomId);
+    if (report == null) {
+      report = getCurrentClusters(roomId);
+    }
+    broadcastClusters(roomId, report);
+  }
+
   @Async("clusterExecutor")
   public void broadcast(String roomId, QuestionInput input) {
     try {
@@ -53,10 +85,7 @@ public class ClusterBroadcaster {
           .block(Duration.ofSeconds(10));
 
       if (resp != null && resp.data() != null) {
-        broker.convertAndSend(
-            "/topic/p/" + roomId + "/clusters",
-            ClusterEvent.updated(resp.data())
-        );
+        broadcastClusters(roomId, resp.data());
         log.info("[CLUSTER] broadcast 완료 (roomId={}, groups={})",
             roomId, resp.data().uniqueGroups());
       }

--- a/src/main/java/line4thon/boini/audience/question/service/QuestionManageService.java
+++ b/src/main/java/line4thon/boini/audience/question/service/QuestionManageService.java
@@ -1,6 +1,8 @@
 package line4thon.boini.audience.question.service;
 
 import line4thon.boini.audience.question.dto.QuestionStatusEvent;
+import line4thon.boini.audience.question.dto.ClusterItem;
+import line4thon.boini.audience.question.dto.response.ClusterReportResponse;
 import line4thon.boini.audience.question.dto.response.CreateQuestionResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +19,7 @@ public class QuestionManageService {
 
   private final StringRedisTemplate redis;
   private final SimpMessagingTemplate broker;
+  private final ClusterBroadcaster clusterBroadcaster;
 
   /**
    * 질문을 완료 처리한다.
@@ -25,16 +28,17 @@ public class QuestionManageService {
    * - 청중/발표자에게 QUESTION_COMPLETED 이벤트 broadcast
    */
   public void complete(String roomId, String questionId) {
-    String hKey = "room:%s:question:%s".formatted(roomId, questionId);
-    redis.opsForHash().put(hKey, "status", "completed");
-    redis.opsForSet().add("room:" + roomId + ":questions:completed", questionId);
+    List<String> targetIds = resolveActionTargetIds(roomId, questionId);
+    for (String targetId : targetIds) {
+      String hKey = "room:%s:question:%s".formatted(roomId, targetId);
+      redis.opsForHash().put(hKey, "status", "completed");
+      redis.opsForSet().add("room:" + roomId + ":questions:completed", targetId);
+      broadcastStatus(roomId, QuestionStatusEvent.completed(targetId));
+    }
 
-    var evt = QuestionStatusEvent.completed(questionId);
-    String base = "/topic/p/" + roomId;
-    broker.convertAndSend(base + "/public", evt);
-    broker.convertAndSend(base + "/presenter", evt);
-
-    log.info("[QUESTION] 완료 처리 (roomId={}, questionId={})", roomId, questionId);
+    clusterBroadcaster.refreshAndBroadcast(roomId);
+    log.info("[QUESTION] 완료 처리 (roomId={}, requestedQuestionId={}, targetIds={})",
+        roomId, questionId, targetIds);
   }
 
   /**
@@ -44,16 +48,55 @@ public class QuestionManageService {
    * - 청중/발표자에게 QUESTION_DELETED 이벤트 broadcast → 실시간 채팅창에서 즉시 제거
    */
   public void delete(String roomId, String questionId) {
-    String hKey = "room:%s:question:%s".formatted(roomId, questionId);
-    redis.opsForHash().put(hKey, "status", "deleted");
-    redis.opsForSet().add("room:" + roomId + ":questions:deleted", questionId);
+    List<String> targetIds = resolveActionTargetIds(roomId, questionId);
+    for (String targetId : targetIds) {
+      String hKey = "room:%s:question:%s".formatted(roomId, targetId);
+      redis.opsForHash().put(hKey, "status", "deleted");
+      redis.opsForSet().add("room:" + roomId + ":questions:deleted", targetId);
+      redis.opsForSet().remove("room:" + roomId + ":questions:completed", targetId);
+      broadcastStatus(roomId, QuestionStatusEvent.deleted(targetId));
+    }
 
-    var evt = QuestionStatusEvent.deleted(questionId);
+    clusterBroadcaster.refreshAndBroadcast(roomId);
+    log.info("[QUESTION] 삭제 처리 (roomId={}, requestedQuestionId={}, targetIds={})",
+        roomId, questionId, targetIds);
+  }
+
+  private List<String> resolveActionTargetIds(String roomId, String questionId) {
+    ClusterReportResponse report = clusterBroadcaster.getCurrentClusters(roomId);
+    if (report == null || report.clusters() == null || report.clusters().isEmpty()) {
+      return List.of(questionId);
+    }
+
+    for (ClusterItem cluster : report.clusters()) {
+      List<String> ids = cluster.questionIds();
+      if (ids == null || ids.isEmpty() || !ids.contains(questionId)) {
+        continue;
+      }
+
+      if (isRepresentativeAction(cluster, questionId)) {
+        return new ArrayList<>(new LinkedHashSet<>(ids));
+      }
+
+      return List.of(questionId);
+    }
+
+    return List.of(questionId);
+  }
+
+  private boolean isRepresentativeAction(ClusterItem cluster, String questionId) {
+    if (questionId.equals(cluster.representativeQuestionId())) {
+      return true;
+    }
+
+    List<String> ids = cluster.questionIds();
+    return ids != null && !ids.isEmpty() && questionId.equals(ids.get(0));
+  }
+
+  private void broadcastStatus(String roomId, QuestionStatusEvent event) {
     String base = "/topic/p/" + roomId;
-    broker.convertAndSend(base + "/public", evt);
-    broker.convertAndSend(base + "/presenter", evt);
-
-    log.info("[QUESTION] 삭제 처리 (roomId={}, questionId={})", roomId, questionId);
+    broker.convertAndSend(base + "/public", event);
+    broker.convertAndSend(base + "/presenter", event);
   }
 
   /**
@@ -69,6 +112,7 @@ public class QuestionManageService {
     for (String qid : completedIds) {
       Map<Object, Object> h = redis.opsForHash().entries("room:%s:question:%s".formatted(roomId, qid));
       if (h == null || h.isEmpty()) continue;
+      if (!"completed".equals(h.get("status"))) continue;
       result.add(new CreateQuestionResponse(
           (String) h.get("id"),
           (String) h.get("roomId"),

--- a/src/test/java/line4thon/boini/audience/question/service/QuestionManageServiceTest.java
+++ b/src/test/java/line4thon/boini/audience/question/service/QuestionManageServiceTest.java
@@ -1,0 +1,131 @@
+package line4thon.boini.audience.question.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import line4thon.boini.audience.question.dto.ClusterItem;
+import line4thon.boini.audience.question.dto.QuestionStatusEvent;
+import line4thon.boini.audience.question.dto.response.ClusterReportResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+class QuestionManageServiceTest {
+
+  private StringRedisTemplate redis;
+  private HashOperations<String, Object, Object> hashOps;
+  private SetOperations<String, String> setOps;
+  private SimpMessagingTemplate broker;
+  private ClusterBroadcaster clusterBroadcaster;
+  private QuestionManageService service;
+
+  @BeforeEach
+  void setUp() {
+    redis = mock(StringRedisTemplate.class);
+    hashOps = mock(HashOperations.class);
+    setOps = mock(SetOperations.class);
+    broker = mock(SimpMessagingTemplate.class);
+    clusterBroadcaster = mock(ClusterBroadcaster.class);
+
+    when(redis.opsForHash()).thenReturn(hashOps);
+    when(redis.opsForSet()).thenReturn(setOps);
+
+    service = new QuestionManageService(redis, broker, clusterBroadcaster);
+  }
+
+  @Test
+  void completeRepresentativeCompletesEveryActiveQuestionInCluster() {
+    when(clusterBroadcaster.getCurrentClusters("room-1")).thenReturn(clusterReport());
+
+    service.complete("room-1", "q1");
+
+    verify(hashOps).put("room:room-1:question:q1", "status", "completed");
+    verify(hashOps).put("room:room-1:question:q2", "status", "completed");
+    verify(setOps).add("room:room-1:questions:completed", "q1");
+    verify(setOps).add("room:room-1:questions:completed", "q2");
+    verify(broker, times(2))
+        .convertAndSend(eq("/topic/p/room-1/public"), any(QuestionStatusEvent.class));
+    verify(broker, times(2))
+        .convertAndSend(eq("/topic/p/room-1/presenter"), any(QuestionStatusEvent.class));
+    verify(clusterBroadcaster).refreshAndBroadcast("room-1");
+  }
+
+  @Test
+  void completeSubQuestionCompletesOnlyClickedQuestion() {
+    when(clusterBroadcaster.getCurrentClusters("room-1")).thenReturn(clusterReport());
+
+    service.complete("room-1", "q2");
+
+    verify(hashOps, never()).put("room:room-1:question:q1", "status", "completed");
+    verify(hashOps).put("room:room-1:question:q2", "status", "completed");
+    verify(setOps, never()).add("room:room-1:questions:completed", "q1");
+    verify(setOps).add("room:room-1:questions:completed", "q2");
+    verify(clusterBroadcaster).refreshAndBroadcast("room-1");
+  }
+
+  @Test
+  void deleteRemovesQuestionFromCompletedSet() {
+    when(clusterBroadcaster.getCurrentClusters("room-1")).thenReturn(null);
+
+    service.delete("room-1", "q1");
+
+    verify(hashOps).put("room:room-1:question:q1", "status", "deleted");
+    verify(setOps).add("room:room-1:questions:deleted", "q1");
+    verify(setOps).remove("room:room-1:questions:completed", "q1");
+  }
+
+  @Test
+  void listCompletedSkipsDeletedOrStaleCompletedSetEntries() {
+    when(setOps.members("room:room-1:questions:completed")).thenReturn(Set.of("q1", "q2"));
+    when(hashOps.entries("room:room-1:question:q1")).thenReturn(Map.of(
+        "id", "q1",
+        "roomId", "room-1",
+        "slide", "1",
+        "audienceId", "a1",
+        "content", "completed",
+        "ts", "100",
+        "status", "completed"
+    ));
+    when(hashOps.entries("room:room-1:question:q2")).thenReturn(Map.of(
+        "id", "q2",
+        "roomId", "room-1",
+        "slide", "1",
+        "audienceId", "a2",
+        "content", "deleted",
+        "ts", "200",
+        "status", "deleted"
+    ));
+
+    var completed = service.listCompleted("room-1");
+
+    assertThat(completed).hasSize(1);
+    assertThat(completed.get(0).id()).isEqualTo("q1");
+  }
+
+  private ClusterReportResponse clusterReport() {
+    ClusterItem cluster = new ClusterItem(
+        "cluster-q1",
+        "q1",
+        "대표 질문",
+        2,
+        List.of(),
+        List.of("q1", "q2"),
+        List.of(1, 2),
+        List.of("대표 질문", "하위 질문")
+    );
+
+    return new ClusterReportResponse("room-1", 2, 1, List.of(cluster));
+  }
+}


### PR DESCRIPTION
- resolve representative actions to active cluster members server-side

- refresh and rebroadcast clusters after complete/delete

- keep deleted questions out of completed lists

- add unit coverage for representative and sub-question actions
