### PR TITLE
feat(feedback): authenticate audience via token and dedupe ratings

### DIFF
--- a/src/main/java/line4thon/boini/audience/feedback/controller/FeedbackAnswerController.java
+++ b/src/main/java/line4thon/boini/audience/feedback/controller/FeedbackAnswerController.java
@@ -1,10 +1,12 @@
 package line4thon.boini.audience.feedback.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import line4thon.boini.audience.feedback.dto.request.SubmitFeedbackAnswersRequest;
 import line4thon.boini.audience.feedback.dto.response.FeedbackAnswersResponse;
 import line4thon.boini.audience.feedback.service.FeedbackAnswerService;
 import line4thon.boini.global.common.response.BaseResponse;
+import line4thon.boini.global.jwt.util.AudienceTokenResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,13 +16,17 @@ import org.springframework.web.bind.annotation.*;
 public class FeedbackAnswerController {
 
   private final FeedbackAnswerService feedbackAnswerService;
+  private final AudienceTokenResolver audienceTokenResolver;
 
   @PostMapping
   @Operation(summary = "세션 후기 답변 제출",
       description = "청중이 발표자가 만든 후기 질문에 대한 답변을 제출합니다. 같은 청중이 다시 제출하면 이전 답변을 교체합니다.")
   public BaseResponse<FeedbackAnswersResponse> submit(
       @PathVariable("roomId") String roomId,
-      @RequestBody SubmitFeedbackAnswersRequest request) {
-    return BaseResponse.success(feedbackAnswerService.submit(roomId, request));
+      @RequestBody SubmitFeedbackAnswersRequest request,
+      HttpServletRequest httpRequest) {
+    // 신원은 요청 본문이 아니라 입장 시 발급된 토큰에서 가져온다.
+    String audienceId = audienceTokenResolver.resolveAudienceId(httpRequest, roomId);
+    return BaseResponse.success(feedbackAnswerService.submit(roomId, audienceId, request));
   }
 }

--- a/src/main/java/line4thon/boini/audience/feedback/controller/FeedbackController.java
+++ b/src/main/java/line4thon/boini/audience/feedback/controller/FeedbackController.java
@@ -1,6 +1,7 @@
 package line4thon.boini.audience.feedback.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
@@ -10,6 +11,7 @@ import line4thon.boini.audience.feedback.dto.request.CreateFeedbackRequest;
 import line4thon.boini.audience.feedback.dto.response.CreateFeedbackResponse;
 import line4thon.boini.audience.feedback.service.FeedbackService;
 import line4thon.boini.global.common.response.BaseResponse;
+import line4thon.boini.global.jwt.util.AudienceTokenResolver;
 
 @RestController
 @RequestMapping("/api/feedbacks")
@@ -18,6 +20,7 @@ import line4thon.boini.global.common.response.BaseResponse;
 public class FeedbackController {
 
   private final FeedbackService feedbackService;
+  private final AudienceTokenResolver audienceTokenResolver;
 
   @PostMapping("/rooms/{roomId}/feedbacks")
   @Operation(
@@ -31,9 +34,12 @@ public class FeedbackController {
   )
   public BaseResponse<CreateFeedbackResponse> createByPath(
       @PathVariable("roomId") String roomId,
-      @Valid @RequestBody CreateFeedbackRequest request
+      @Valid @RequestBody CreateFeedbackRequest request,
+      HttpServletRequest httpRequest
   ) {
-    var resp = feedbackService.write(roomId, request);
+    // 신원은 요청 본문이 아니라 입장 시 발급된 토큰에서 가져온다.
+    String audienceId = audienceTokenResolver.resolveAudienceId(httpRequest, roomId);
+    var resp = feedbackService.write(roomId, audienceId, request);
     return BaseResponse.success(resp);
   }
 }

--- a/src/main/java/line4thon/boini/audience/feedback/entity/FeedbackEntity.java
+++ b/src/main/java/line4thon/boini/audience/feedback/entity/FeedbackEntity.java
@@ -10,7 +10,11 @@ import java.time.Instant;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "feedbacks")
+@Table(
+    name = "feedbacks",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uq_feedbacks_room_audience",
+        columnNames = {"roomId", "audienceId"}))
 public class FeedbackEntity {
 
   @Id

--- a/src/main/java/line4thon/boini/audience/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/line4thon/boini/audience/feedback/repository/FeedbackRepository.java
@@ -4,9 +4,13 @@ import java.util.List;
 import line4thon.boini.audience.feedback.entity.FeedbackEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface FeedbackRepository extends JpaRepository<FeedbackEntity, Long> {
   List<FeedbackEntity> findByRoomIdOrderByCreatedAtDesc(String roomId);
   List<FeedbackEntity> findByRoomIdAndAudienceIdOrderByCreatedAtDesc(String roomId, String audienceId);
+
+  @Transactional
+  void deleteByRoomIdAndAudienceId(String roomId, String audienceId);
 }

--- a/src/main/java/line4thon/boini/audience/feedback/service/FeedbackAnswerService.java
+++ b/src/main/java/line4thon/boini/audience/feedback/service/FeedbackAnswerService.java
@@ -19,16 +19,18 @@ public class FeedbackAnswerService {
 
   private final FeedbackAnswerRepository repository;
 
+  /**
+   * @param audienceId 인증된 청중 토큰에서 추출한 신원 (요청 본문 값이 아님)
+   */
   @Transactional
-  public FeedbackAnswersResponse submit(String roomId, SubmitFeedbackAnswersRequest request) {
+  public FeedbackAnswersResponse submit(String roomId, String audienceId, SubmitFeedbackAnswersRequest request) {
     if (roomId == null || roomId.isBlank()) {
       throw new CustomException(FeedbackErrorCode.EMPTY_ROOM_ID);
     }
-    if (request.getAudienceId() == null || request.getAudienceId().isBlank()) {
+    if (audienceId == null || audienceId.isBlank()) {
       throw new CustomException(FeedbackErrorCode.EMPTY_ROOM_ID);
     }
 
-    String audienceId = request.getAudienceId();
     repository.deleteByRoomIdAndAudienceId(roomId, audienceId);
 
     List<AnswerItem> incoming = request.getAnswers() == null ? List.of() : request.getAnswers();

--- a/src/main/java/line4thon/boini/audience/feedback/service/FeedbackService.java
+++ b/src/main/java/line4thon/boini/audience/feedback/service/FeedbackService.java
@@ -9,6 +9,7 @@ import line4thon.boini.audience.feedback.repository.FeedbackRepository;
 import line4thon.boini.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -16,7 +17,11 @@ public class FeedbackService {
 
    private final FeedbackRepository feedbackRepository;
 
-  public CreateFeedbackResponse write(String roomId, CreateFeedbackRequest request) {
+  /**
+   * @param audienceId 인증된 청중 토큰에서 추출한 신원 (요청 본문 값이 아님)
+   */
+  @Transactional
+  public CreateFeedbackResponse write(String roomId, String audienceId, CreateFeedbackRequest request) {
 
     if (roomId == null || roomId.isBlank()) {
       throw new CustomException(FeedbackErrorCode.EMPTY_ROOM_ID);
@@ -29,9 +34,14 @@ public class FeedbackService {
     try {
       Instant now = Instant.now();
 
+      // 한 청중은 방당 하나의 평가만 남긴다. 재제출 시 이전 평가를 교체한다.
+      // unique 제약과 충돌하지 않도록 INSERT 전에 DELETE 를 먼저 flush 한다.
+      feedbackRepository.deleteByRoomIdAndAudienceId(roomId, audienceId);
+      feedbackRepository.flush();
+
       FeedbackEntity entity = FeedbackEntity.builder()
           .roomId(roomId)
-          .audienceId(request.getAudienceId())
+          .audienceId(audienceId)
           .rating(request.getRating())
           .comment(request.getComment())
           .createdAt(now)
@@ -42,12 +52,14 @@ public class FeedbackService {
       return CreateFeedbackResponse.builder()
           .id(saved.getId())
           .roomId(roomId)
-          .audienceId(request.getAudienceId())
+          .audienceId(audienceId)
           .rating(request.getRating())
           .comment(request.getComment())
           .createdAt(now)
           .build();
 
+    } catch (CustomException e) {
+      throw e;
     } catch (Exception e) {
       throw new CustomException(FeedbackErrorCode.SAVE_FAILED);
     }

--- a/src/main/java/line4thon/boini/global/jwt/util/AudienceTokenResolver.java
+++ b/src/main/java/line4thon/boini/global/jwt/util/AudienceTokenResolver.java
@@ -1,0 +1,75 @@
+package line4thon.boini.global.jwt.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import line4thon.boini.global.common.exception.CustomException;
+import line4thon.boini.global.jwt.exception.JwtErrorCode;
+import line4thon.boini.global.jwt.service.JwtService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 청중용 REST 요청에서 Authorization: Bearer 토큰을 검증하고 청중 신원을 추출한다.
+ *
+ * <p>토큰은 입장(join) 시 서버가 서명해 발급한 것이므로, 유효한 서명은 곧 "이 방에 실제로
+ * 입장한 청중"이라는 증명이 된다. 따라서 audienceId 를 요청 본문이 아니라 토큰의 subject 에서
+ * 가져오면 위조/무단 제출을 원천 차단할 수 있다.
+ */
+@Component
+@RequiredArgsConstructor
+public class AudienceTokenResolver {
+
+  private static final String ROLE_AUDIENCE = "audience";
+
+  private final JwtService jwtService;
+
+  /**
+   * 요청의 Bearer 토큰을 검증하고, 경로의 roomId 와 일치하는 방의 청중이면 audienceId 를 반환한다.
+   *
+   * @param request     현재 HTTP 요청 (Authorization 헤더에서 토큰을 읽는다)
+   * @param expectedRoomId 경로 변수로 전달된 roomId (토큰의 roomId 클레임과 일치해야 한다)
+   * @return 토큰 subject 에 담긴 audienceId
+   */
+  public String resolveAudienceId(HttpServletRequest request, String expectedRoomId) {
+    String token = extractBearerToken(request);
+
+    Claims claims;
+    try {
+      claims = jwtService.parse(token);
+    } catch (ExpiredJwtException e) {
+      throw new CustomException(JwtErrorCode.JWT_EXPIRED);
+    } catch (Exception e) {
+      throw new CustomException(JwtErrorCode.JWT_INVALID);
+    }
+
+    String role = claims.get("role", String.class);
+    String roomId = claims.get("roomId", String.class);
+    String audienceId = claims.getSubject();
+
+    if (role == null || roomId == null || audienceId == null || audienceId.isBlank()) {
+      throw new CustomException(JwtErrorCode.JWT_CLAIM_INVALID);
+    }
+    if (!ROLE_AUDIENCE.equalsIgnoreCase(role)) {
+      throw new CustomException(JwtErrorCode.JWT_CLAIM_INVALID);
+    }
+    // 토큰이 발급된 방과 요청 대상 방이 다르면 다른 방의 신원으로 위장한 것이다.
+    if (expectedRoomId == null || !roomId.equals(expectedRoomId)) {
+      throw new CustomException(JwtErrorCode.JWT_CLAIM_INVALID);
+    }
+
+    return audienceId;
+  }
+
+  private String extractBearerToken(HttpServletRequest request) {
+    String header = request.getHeader("Authorization");
+    if (header == null || !header.regionMatches(true, 0, "Bearer ", 0, 7)) {
+      throw new CustomException(JwtErrorCode.JWT_MISSING);
+    }
+    String token = header.substring(7).trim();
+    if (token.isEmpty()) {
+      throw new CustomException(JwtErrorCode.JWT_MISSING);
+    }
+    return token;
+  }
+}


### PR DESCRIPTION
Feedback and feedback-answer endpoints previously trusted an audienceId sent in the request body with no auth, so anyone knowing a roomId could forge/spam ratings and answers via direct API calls.

- Add AudienceTokenResolver: validates the Bearer audience JWT (signature, expiry, role=audience) and requires its roomId claim to match the path, deriving audienceId from the token subject. A valid signed token is proof of membership in that room, closing both the no-auth and cross-room gaps.
- FeedbackController / FeedbackAnswerController now derive audienceId from the token instead of the request body.
- Enforce one rating per (roomId, audienceId): add a unique constraint and upsert via delete-then-insert (flush between to satisfy the constraint).