### PR TITLE
🐛 [FIX] 커스텀 질문 사용 시 PDF 다운로드 자격 인정

### DIFF
--- a/src/main/java/line4thon/boini/audience/feedback/repository/FeedbackAnswerRepository.java
+++ b/src/main/java/line4thon/boini/audience/feedback/repository/FeedbackAnswerRepository.java
@@ -12,6 +12,8 @@ public interface FeedbackAnswerRepository extends JpaRepository<FeedbackAnswerEn
 
   List<FeedbackAnswerEntity> findByRoomIdAndAudienceId(String roomId, String audienceId);
 
+  boolean existsByRoomIdAndAudienceId(String roomId, String audienceId);
+
   @Transactional
   void deleteByRoomIdAndAudienceId(String roomId, String audienceId);
 }

--- a/src/main/java/line4thon/boini/presenter/room/contorller/RoomController.java
+++ b/src/main/java/line4thon/boini/presenter/room/contorller/RoomController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import line4thon.boini.audience.feedback.entity.FeedbackEntity;
+import line4thon.boini.audience.feedback.repository.FeedbackAnswerRepository;
 import line4thon.boini.audience.feedback.repository.FeedbackRepository;
 import line4thon.boini.audience.room.dto.request.LeaveRoomRequest;
 import line4thon.boini.audience.room.dto.response.JoinResponse;
@@ -64,6 +65,7 @@ public class RoomController {
   private final JwtService jwtService;
   private final SimpMessagingTemplate messagingTemplate;
   private final FeedbackRepository feedbackRepository;
+  private final FeedbackAnswerRepository feedbackAnswerRepository;
   private final S3Client s3Client;
   private final AppProperties props;
 
@@ -331,15 +333,28 @@ public class RoomController {
       return false;
     }
 
-    return feedbackRepository.findByRoomIdAndAudienceIdOrderByCreatedAtDesc(roomId, audienceId).stream()
-        .anyMatch(this::hasRatingAndWrittenFeedback);
+    var feedbacks =
+        feedbackRepository.findByRoomIdAndAudienceIdOrderByCreatedAtDesc(roomId, audienceId);
+
+    // 레거시(질문 없는) 후기: 별점 + 코멘트가 모두 채워진 단일 후기.
+    if (feedbacks.stream().anyMatch(this::hasRatingAndWrittenFeedback)) {
+      return true;
+    }
+
+    // 발표자가 커스텀 질문을 사용하는 경우: 별점은 제출되지만 comment 는 비어 있고,
+    // 실제 주관식 답변은 feedback_answers 에 저장된다. 이 경우도 제출 완료로 인정한다.
+    boolean hasRating = feedbacks.stream().anyMatch(this::hasValidRating);
+    return hasRating && feedbackAnswerRepository.existsByRoomIdAndAudienceId(roomId, audienceId);
   }
 
   private boolean hasRatingAndWrittenFeedback(FeedbackEntity feedback) {
-    return feedback.getRating() >= 1
-        && feedback.getRating() <= 5
+    return hasValidRating(feedback)
         && feedback.getComment() != null
         && !feedback.getComment().isBlank();
+  }
+
+  private boolean hasValidRating(FeedbackEntity feedback) {
+    return feedback.getRating() >= 1 && feedback.getRating() <= 5;
   }
 
   private String contentDisposition(String roomId) {


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- 없음


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 발표자가 **커스텀 피드백 질문**을 사용할 때, 청중이 세션 PDF를 영구적으로 다운로드하지 못하던 문제 수정
- `RoomController.hasSubmittedWrittenFeedback`가 `comment`가 채워진 후기만 제출로 인정했으나, 커스텀 질문 플로우는 `comment`를 비운 채 주관식 답변을 `feedback_answers`에 저장 → `submittedFeedback`이 항상 `false`가 되어 `canDownload`가 참이 되지 못함
- 유효한 별점 + `feedback_answers`에 해당 방/청중의 답변이 존재하면 제출 완료로 인정 (레거시 comment 경로는 그대로 유지)
- `FeedbackAnswerRepository.existsByRoomIdAndAudienceId` 추가
- 두 경로가 공유하는 `hasValidRating` 헬퍼 추출


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`develop` 대상, `main` 아님)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가? (`./gradlew compileJava` 성공)


## 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
- 더 이상 필요 없어진 "다운로드 불가" 알림을 제거하는 프론트엔드 PR과 함께 머지되어야 합니다.


## ➕ 추후 계획(선택)
